### PR TITLE
Fixes centering on mobile

### DIFF
--- a/assets/css/custom.css
+++ b/assets/css/custom.css
@@ -108,6 +108,10 @@ footer {
   text-align: center;
 }
 
+#page {
+  padding-left: 0;
+}
+
 #page h2 {
   font-weight: 700;
   padding-top: 110px;


### PR DESCRIPTION
This fixes some weird centering on mobile caused by padding.

Before:
![image](https://user-images.githubusercontent.com/79141224/135361192-3d439701-7ed8-44c0-b671-48d3a017a87c.png)

After
![image](https://user-images.githubusercontent.com/79141224/135361224-51a7d8f3-e637-490a-a8ba-c0cc941f3000.png)
