### PR TITLE
Update projects.yaml & replace term 'Free' with 'Open Source'

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -270,7 +270,7 @@ GEM
     zeitwerk (2.4.2)
 
 PLATFORMS
-  universal-darwin-20
+  universal-darwin-21
   x86_64-linux
 
 DEPENDENCIES
@@ -280,4 +280,4 @@ DEPENDENCIES
   wdm (~> 0.1.1)
 
 BUNDLED WITH
-   2.2.24
+   2.2.32

--- a/_config.yml
+++ b/_config.yml
@@ -1,5 +1,5 @@
-title: Spotify Free Software
-description: Free and Open Source Software projects by Spotify
+title: Spotify Open Source Projects
+description: Open Source Software developed at Spotify
 baseurl: "" # the subpath of your site, e.g. /blog
 url: "https://spotify.github.io" # the base hostname & protocol for your site, e.g. http://example.com
 twitter_username: SpotifyEng

--- a/_data/projects.yaml
+++ b/_data/projects.yaml
@@ -13,6 +13,7 @@
     - url: https://github.com/spotify/NFDriver
     - url: https://github.com/spotify/NFParam
     - url: https://github.com/spotify/pedalboard
+    - url: https://github.com/spotify/NFHTTP
 - config:
     id: cassandra
     name: Cassandra
@@ -28,12 +29,11 @@
       <i class="devicon-docker-plain"></i>
   projects:
     - url: https://github.com/spotify/docker-bigtable
-    - url: https://github.com/spotify/docker-client
-    - url: https://github.com/spotify/docker-kafka
-    - url: https://github.com/spotify/docker-maven-plugin
+    - url: https://github.com/spotify/dockerfile-maven
     - url: https://github.com/spotify/dockerfile-maven
     - url: https://github.com/spotify/styx
     - url: https://github.com/spotify/docker_interface
+    - url: https://github.com/spotify/dockerfile-mode
 - config:
     id: java
     name: Java
@@ -44,8 +44,7 @@
     - url: https://github.com/spotify/android-sdk
     - url: https://github.com/spotify/apollo
     - url: https://github.com/spotify/completable-futures
-    - url: https://github.com/spotify/docker-client
-    - url: https://github.com/spotify/docker-maven-plugin
+    - url: https://github.com/spotify/dockerfile-maven
     - url: https://github.com/spotify/dockerfile-maven
     - url: https://github.com/spotify/ffwd
     - url: https://github.com/spotify/folsom
@@ -104,6 +103,8 @@
     - url: https://github.com/spotify/chartify
     - url: https://github.com/spotify/klio
     - url: https://github.com/spotify/pedalboard
+    - url: https://github.com/spotify/confidence
+    - url: https://github.com/spotify/postgresql-metrics
 - config:
     id: ruby
     name: Ruby
@@ -129,6 +130,9 @@
   projects:
     - url: https://github.com/spotify/Mobius.swift
     - url: https://github.com/spotify/SpotifyLogin
+    - url: https://github.com/spotify/XCRemoteCache
+    - url: https://github.com/spotify/XCMetrics
+
 - config:
     id: other
     name: Other

--- a/assets/html/intro.html
+++ b/assets/html/intro.html
@@ -69,10 +69,10 @@
       <div class="row">
         <div class="col-sm-9">
           <p>
-            Building Spotify would not have been possible without Free and Open
-            Source Software. We wanted to do our bit to give back to the
-            community, and here’s some of that software. We hope you’ll find it
-            useful. For a full list, see our
+            Building Spotify would not have been possible without Open Source
+            Software. We wanted to do our bit to give back to the community, and
+            here’s some of that software. We hope you’ll find it useful. For a
+            full list, see our
             <a href="https://github.com/spotify">GitHub</a>.
           </p>
 


### PR DESCRIPTION
- Add more projects
- Removing the term "Free" & replace it with "Open Source", because if you Google e.g. "Spotify Open Source" this website will show as the first result & it will look a bit misleading:
![Screenshot 2021-11-29 at 13 25 52](https://user-images.githubusercontent.com/8904624/143867887-8ede75a4-29cb-4ae6-a0ab-519fb5007c1d.png)
