### PR TITLE
Add some missing icons

### DIFF
--- a/_data/projects.yaml
+++ b/_data/projects.yaml
@@ -77,6 +77,8 @@
 - config:
     id: kotlin
     name: Kotlin
+    icons_html: >
+      <i class="devicon-kotlin-plain"></i>
   projects:
     - url: https://github.com/spotify/ruler
 - config:

--- a/_data/projects.yaml
+++ b/_data/projects.yaml
@@ -84,6 +84,8 @@
 - config:
     id: objective-c
     name: Objective-C
+    icons_html: >
+      <i class="devicon-objectivec-plain"></i>  
   projects:
     - url: https://github.com/spotify/ios-style
     - url: https://github.com/spotify/ios-sdk

--- a/_data/projects.yaml
+++ b/_data/projects.yaml
@@ -119,6 +119,8 @@
 - config:
     id: scala
     name: Scala
+    icons_html: >
+      <i class=devicon-scala-plain"></i>
   projects:
     - url: https://github.com/spotify/big-data-rosetta-code
     - url: https://github.com/spotify/featran

--- a/_data/projects_generated.yaml
+++ b/_data/projects_generated.yaml
@@ -483,6 +483,8 @@
 - config:
     id: objective-c
     name: Objective-C
+    icons_html: >
+      <i class="devicon-objectivec-plain"></i>  
   projects:
     - name: ios-style
       description: Guidelines for iOS development in use at Spotify

--- a/_data/projects_generated.yaml
+++ b/_data/projects_generated.yaml
@@ -468,6 +468,8 @@
 - config:
     id: kotlin
     name: Kotlin
+    icons_html: |
+      <i class="devicon-kotlin-plain"></i>
   projects:
     - name: ruler
       description: Gradle plugin which helps you analyze the size of your Android apps.

--- a/_data/projects_generated.yaml
+++ b/_data/projects_generated.yaml
@@ -691,6 +691,8 @@
 - config:
     id: scala
     name: Scala
+    icons_html: |
+      <i class="devicon-scala-plain"></i>
   projects:
     - name: big-data-rosetta-code
       description: Code snippets for solving common big data problems in various

--- a/index.html
+++ b/index.html
@@ -28,7 +28,7 @@
 
     <link href="https://www.scdn.co/i/_global/favicon.png" rel="icon" />
     <link
-      href="https://cdn.rawgit.com/konpa/devicon/df6431e323547add1b4cf45992913f15286456d3/devicon.min.css"
+    href="https://cdn.jsdelivr.net/gh/devicons/devicon@latest/devicon.min.css"
       rel="stylesheet"
     />
     <!-- <link href="assets/octicons/octicons.css" rel="stylesheet" type="text/css"> -->


### PR DESCRIPTION
Hello @tudi2d !

I noticed that a few programming language icons were missing, so I'm trying to add them with this PR! Similarly to what was suggested in #9 .

[Edit] Note for the reviewer: I just saw that my edits are very similar to #7 ! With the difference that in this PR, also Kotlin's icon is added.

I've changed the source for devicons from `"https://cdn.rawgit.com/konpa/devicon/df6431e323547add1b4cf45992913f15286456d3/devicon.min.css"` to `href="https://cdn.jsdelivr.net/gh/devicons/devicon@latest/devicon.min.css"`.

P.S. The Cassandra icon should be on her way --> devicons/devicon#1192