### PR TITLE
node version update [stable] + minor UI updates

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -11,7 +11,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [14.x]
+        node-version: [16.x]
 
     env:
       CI: true

--- a/_data/projects.yaml
+++ b/_data/projects.yaml
@@ -14,6 +14,7 @@
     - url: https://github.com/spotify/NFParam
     - url: https://github.com/spotify/pedalboard
     - url: https://github.com/spotify/NFHTTP
+    
 - config:
     id: cassandra
     name: Cassandra
@@ -22,6 +23,7 @@
     - url: https://github.com/spotify/cassandra-reaper
     - url: https://github.com/spotify/cstar
     - url: https://github.com/spotify/hdfs2cass
+
 - config:
     id: docker
     name: Docker
@@ -33,6 +35,7 @@
     - url: https://github.com/spotify/styx
     - url: https://github.com/spotify/docker_interface
     - url: https://github.com/spotify/dockerfile-mode
+
 - config:
     id: java
     name: Java
@@ -55,6 +58,7 @@
     - url: https://github.com/spotify/spydra
     - url: https://github.com/spotify/styx
     - url: https://github.com/spotify/zoltar
+
 - config:
     id: javascript
     name: JavaScript
@@ -74,19 +78,26 @@
     - url: https://github.com/spotify/web-audio-bench
     - url: https://github.com/spotify/web-scripts
     - url: https://github.com/spotify/web-scripts-library-template
+
 - config:
     id: kotlin
     name: Kotlin
+    icons_html: >
+      <i class="devicon-kotlin-plain"></i>
   projects:
     - url: https://github.com/spotify/ruler
+
 - config:
     id: objective-c
     name: Objective-C
+    icons_html: >
+      <i class="devicon-objectivec-plain"></i>
   projects:
     - url: https://github.com/spotify/ios-style
     - url: https://github.com/spotify/ios-sdk
     - url: https://github.com/spotify/SPTDataLoader
     - url: https://github.com/spotify/SPTPersistentCache
+
 - config:
     id: python
     name: Python
@@ -108,6 +119,7 @@
     - url: https://github.com/spotify/pedalboard
     - url: https://github.com/spotify/confidence
     - url: https://github.com/spotify/postgresql-metrics
+
 - config:
     id: ruby
     name: Ruby
@@ -116,15 +128,19 @@
   projects:
     - url: https://github.com/spotify/moob
     - url: https://github.com/spotify/rspec-dns
+
 - config:
     id: scala
     name: Scala
+    icons_html: >
+      <i class="devicon-scala-plain"></i>
   projects:
     - url: https://github.com/spotify/big-data-rosetta-code
     - url: https://github.com/spotify/featran
     - url: https://github.com/spotify/noether
     - url: https://github.com/spotify/ratatool
     - url: https://github.com/spotify/scio
+
 - config:
     id: swift
     name: Swift

--- a/package.json
+++ b/package.json
@@ -3,8 +3,8 @@
   "version": "0.0.1",
   "description": "Free and Open Source Software projects by Spotify",
   "dependencies": {
-    "@octokit/graphql": "^4.6.4",
-    "yaml": "^1.10.2"
+    "@octokit/graphql": "^5.0.5",
+    "yaml": "^2.2.1"
   },
   "type": "module",
   "repository": {


### PR DESCRIPTION
### Issue + Solution:

- [All GitHub Actions will begin to run on **Node16** (stable) instead of Node12](https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12) starting this [summer](https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/#:~:text=we%20have%20started%20the%20deprecation%20process%20of%20Node%2012%20for%20GitHub%20Actions.%20We%20plan%20to%20migrate%20all%20actions%20to%20run%20on%20Node16%20by%20Summer%202023). Hence, the changes contain updating node version of workflows to _**16**_ from [_14_](https://github.com/spotify/spotify.github.io/blob/894b513861b5b93c0b4720e0f9160e5424e300f5/.github/workflows/nightly.yml#L14) to ensure it's operationality. 

- Besides, [two packages](https://github.com/spotify/spotify.github.io/blob/main/package.json#L6toL7) have been updated to their latest!

- Moreover, it was also lacking a few icons ([Kotlin](https://spotify.github.io/#kotlin), [Objective-C](https://spotify.github.io/#objective-c), [Scala](https://spotify.github.io/#scala)) which have been added.


### Checklist:

- [x] I have explained the need for this PR and the problem it solves
- [x] I have explained the changes or the new features added to this PR

Signed-off-by: Pratyay Banerjee <dev@neilblaze.live>
