### PR TITLE
Fix scala icon

### DIFF
--- a/_data/projects.yaml
+++ b/_data/projects.yaml
@@ -102,7 +102,7 @@
     id: scala
     name: Scala
     icons_html: >
-      <i class=devicon-scala-plain"></i>
+      <i class="devicon-scala-plain"></i>
   projects:
     - url: https://github.com/spotify/big-data-rosetta-code
     - url: https://github.com/spotify/featran


### PR DESCRIPTION
Just adding a double quote to fix the scala icon not being parsed correctly in the webpage.