### PR TITLE
Add Helios to OSS Projects + Improve README Setup Guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,19 +51,20 @@ bundle exec jekyll serve
 Open your browser at [localhost](http://localhost:4000)
 
 ## File Structure
-```text
+```
+text
 .
-├── [_data/](./_data/)
-│   ├── [_data/projects.yml](./_data/projects.yml)     # Hand-picked projects (you can add here!)
-│   └── [_data/projects_generated.yaml](./_data/projects_generated.yaml)   # Auto-generated (DO NOT EDIT)
-├── [scripts/](./scripts/)
-│   └── [scripts/nightly.js](./scripts/nightly.js)              # GitHub API fetcher
-├── [_includes/](./_includes/)
-├── [_layouts/](./_layouts/)
-├── [_site/](./_site/)                        # Generated site output (ignored)
-├── [assets/](./assets/)
-├── [index.html](./index.html)
-└── [README.md](./README.md)
+├── [_data/]
+│   ├── [_data/projects.yml]    # Hand-picked projects (you can add here!)
+│   └── [_data/projects_generated.yaml]   # Auto-generated (DO NOT EDIT)
+├── [scripts/]
+│   └── [scripts/nightly.js]         # GitHub API fetcher
+├── [_includes/]
+├── [_layouts/]
+├── [_site/]                      # Generated site output (ignored)
+├── [assets/]
+├── [index.html]
+└── [README.md]
 ```
 
 

--- a/README.md
+++ b/README.md
@@ -51,20 +51,19 @@ bundle exec jekyll serve
 Open your browser at [localhost](http://localhost:4000)
 
 ## File Structure
-
+```text
 .
-├── _data/
-│   ├── projects.yml              # Hand-picked projects (you can add here!)
-│   └── projects_generated.yaml   # Auto-generated (DO NOT EDIT)
-├── scripts/
-│   └── nightly.js                # GitHub API fetcher
-├── _includes/
-├── _layouts/
-├── _site/                        # Generated site output (ignored)
-├── assets/
-├── index.html
-└── README.md
-
+├── [_data/](./_data/)
+│   ├── [_data/projects.yml](./_data/projects.yml)              # Hand-picked projects (you can add here!)
+│   └── [_data/projects_generated.yaml](./_data/projects_generated.yaml)   # Auto-generated (DO NOT EDIT)
+├── [scripts/](./scripts/)
+│   └── [scripts/nightly.js](./scripts/nightly.js)              # GitHub API fetcher
+├── [_includes/](./_includes/)
+├── [_layouts/](./_layouts/)
+├── [_site/](./_site/)                        # Generated site output (ignored)
+├── [assets/](./assets/)
+├── [index.html](./index.html)
+└── [README.md](./README.md)
 
 
 

--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ Open your browser at [localhost](http://localhost:4000)
 ```text
 .
 ├── [_data/](./_data/)
-│   ├── [_data/projects.yml](./_data/projects.yml)              # Hand-picked projects (you can add here!)
+│   ├── [_data/projects.yml](./_data/projects.yml)     # Hand-picked projects (you can add here!)
 │   └── [_data/projects_generated.yaml](./_data/projects_generated.yaml)   # Auto-generated (DO NOT EDIT)
 ├── [scripts/](./scripts/)
 │   └── [scripts/nightly.js](./scripts/nightly.js)              # GitHub API fetcher
@@ -64,7 +64,7 @@ Open your browser at [localhost](http://localhost:4000)
 ├── [assets/](./assets/)
 ├── [index.html](./index.html)
 └── [README.md](./README.md)
-
+```
 
 
 This project adheres to the [Open Code of Conduct][code-of-conduct]. By participating, you are expected to honor this code.

--- a/README.md
+++ b/README.md
@@ -1,47 +1,74 @@
 # spotify.github.io
 
 <p align="center">
-  <img src="https://user-images.githubusercontent.com/8904624/127524940-37bd6001-647d-40ac-86ec-bb22d1a100c8.gif">
+  <img src="https://user-images.githubusercontent.com/8904624/127524940-37bd6001-647d-40ac-86ec-bb22d1a100c8.gif" alt="Spotify Open Source">
 </p>
 
-Showcase site for hand-picked open-source projects by Spotify. It is built using Jekyll & GitHub Actions with a Node.js script to fetch data from the GitHub GraphQL API adding it to a static YAML file in the repository.
+A showcase site for hand-picked open-source projects by Spotify.  
+It is built using [Jekyll](https://jekyllrb.com/) and GitHub Actions, with a Node.js script that fetches data from the GitHub GraphQL API and stores it in a YAML file.
 
-## Development
+---
 
-**Install Jekyll & bundler gems**
+## Features
 
+- Automatically updated list of Spotify OSS projects
+- Categorized by programming language
+- Fast static site built with Jekyll
+- Easy to contribute via YAML config
+
+---
+
+## Local Development
+
+### 1. Install Requirements
+
+
+Install [Jekyll](https://jekyllrb.com/) and [Bundler](https://bundler.io/):
 ```sh
 gem install jekyll bundler
 ```
-
-**Install yarn**
+Install Yarn:
 
 ```sh
 npm install --global yarn
 ```
 
-**Install dependencies** inside of the project folder
+### 2. Install Dependencies
+
+Run inside the project root:
 
 ```sh
-yarn & bundle install
+yarn
+bundle install
 ```
 
-**Build & serve**
+### 3. Run the Local Server
 
 ```sh
 bundle exec jekyll serve
 ```
 
-**(Optional) Test & update data**
+Open your browser at [localhost](http://localhost:4000)
 
-[Create a personal GitHub Access Token](https://github.com/settings/tokens) to fetch & update the repository data locally. As the data is updated automatically using GitHub Actions `_data/projects_generated.yaml` should not be added to Git.
+## File Structure
 
-```sh
-GH_TOKEN=YOUR_TOKEN node ./scripts/nightly.js
-```
+.
+├── _data/
+│   ├── projects.yml              # Hand-picked projects (you can add here!)
+│   └── projects_generated.yaml   # Auto-generated (DO NOT EDIT)
+├── scripts/
+│   └── nightly.js                # GitHub API fetcher
+├── _includes/
+├── _layouts/
+├── _site/                        # Generated site output (ignored)
+├── assets/
+├── index.html
+└── README.md
 
----
+
+
 
 This project adheres to the [Open Code of Conduct][code-of-conduct]. By participating, you are expected to honor this code.
 
 [code-of-conduct]: https://github.com/spotify/code-of-conduct/blob/master/code-of-conduct.md
+

--- a/_data/projects.yaml
+++ b/_data/projects.yaml
@@ -144,3 +144,4 @@
     - url: https://github.com/spotify/cstar
     - url: https://github.com/spotify/dockerfile-mode
     - url: https://github.com/spotify/foss-root
+    - url: https://github.com/spotify/helios


### PR DESCRIPTION
This PR adds the Helios project to the "Other" category in _data/projects.yml. Helios is a Docker orchestration platform by Spotify.

It also improves the README.md with clearer local development setup steps using Jekyll and Bundler, making it easier for new contributors to get started.

Let me know if you'd like me to add more projects or further improve the site.
