### PR TITLE
docs: fix shell operator in README install instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ npm install --global yarn
 **Install dependencies** inside of the project folder
 
 ```sh
-yarn & bundle install
+yarn && bundle install
 ```
 
 **Build & serve**


### PR DESCRIPTION
## Summary

Fix 1 issue in 1 file:

- `README.md`: `yarn & bundle install` → `yarn && bundle install` (use sequential `&&` operator instead of background `&` so both commands run in order)

No functional changes — documentation/instructions only.

## Findings breakdown

| File | Wrong | Correct | Verdict |
|---|---|---|---|
| `README.md` | `inside of the project folder` | `inside the project folder` | STYLE — dropped (both forms are grammatically acceptable) |
| `README.md` | `yarn & bundle install` | `yarn && bundle install` | BUG — kept (`&` backgrounds `yarn` instead of running sequentially) |